### PR TITLE
Add placeholder pages for ads, logs, and settings

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,13 +5,12 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Layout from "./components/Layout";
 import Home from "./pages/Home";
+import Ads from "./pages/Ads";
+import Logs from "./pages/Logs";
+import Settings from "./pages/Settings";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { setToken, getMe } from "./api";
 import useIdleTimer from "./hooks/useIdleTimer";
-
-const Ads = () => <div className="p-6">광고 관리 페이지</div>;
-const Logs = () => <div className="p-6">로그 조회 페이지</div>;
-const Settings = () => <div className="p-6">설정 페이지</div>;
 
 export default function App() {
   const [token, setTok] = useState(localStorage.getItem("token"));

--- a/frontend/src/pages/Ads.jsx
+++ b/frontend/src/pages/Ads.jsx
@@ -1,0 +1,5 @@
+export default function Ads() {
+  return (
+    <div className="p-6">광고 관리 페이지</div>
+  );
+}

--- a/frontend/src/pages/Logs.jsx
+++ b/frontend/src/pages/Logs.jsx
@@ -1,0 +1,5 @@
+export default function Logs() {
+  return (
+    <div className="p-6">로그 조회 페이지</div>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,0 +1,5 @@
+export default function Settings() {
+  return (
+    <div className="p-6">설정 페이지</div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Ads, Logs, and Settings pages under `frontend/src/pages`
- wire new pages into routing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7da571394832581e63c5d23d89708