### PR TITLE
Respect explicit service availability flag

### DIFF
--- a/frontend/src/utils/serviceWindow.js
+++ b/frontend/src/utils/serviceWindow.js
@@ -54,19 +54,49 @@ function resolveAvailability(input) {
   );
 }
 
+function normalizeAvailability(value) {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return undefined;
+    return value !== 0;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const lower = trimmed.toLowerCase();
+    if (["y", "yes", "true", "1", "available", "ok", "enable", "enabled"].includes(lower)) {
+      return true;
+    }
+    if (["n", "no", "false", "0", "unavailable", "disabled", "disable"].includes(lower)) {
+      return false;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 export function computeServiceWindow(input) {
   const start = parseDateValue(resolveStart(input));
   const end = parseDateValue(resolveEnd(input));
   const now = new Date();
   const computedAvailable = (!start || now >= start) && (!end || now <= end);
-  const explicitAvailable = resolveAvailability(input);
-  const available = explicitAvailable ?? computedAvailable;
+  const explicitAvailable = normalizeAvailability(resolveAvailability(input));
+
+  const available =
+    explicitAvailable !== undefined
+      ? explicitAvailable
+      : computedAvailable;
 
   let status = "available";
   if (!available) {
-    if (start && now < start) status = "scheduled";
-    else if (end && now > end) status = "expired";
-    else status = "unavailable";
+    if (start && now < start) {
+      status = "scheduled";
+    } else if (end && now > end) {
+      status = "expired";
+    } else {
+      status = "unavailable";
+    }
   }
 
   return { available, status, start, end };


### PR DESCRIPTION
## Summary
- rely on the explicit service availability flag when it is provided
- return an unavailable status when the account is not currently allowed to use the dashboard

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e54d5cceb883258276eda0e9be55fb